### PR TITLE
chore: update `deployment.yml`

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: styfle/cancel-workflow-action@0.9.1
 
       # This step checks out a copy of your repository.
       - uses: actions/checkout@v2


### PR DESCRIPTION
No need to pass the `access_token` anymore, as it defaults to `secrets.GITHUB_TOKEN`